### PR TITLE
Remove unnecessary selenium dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-selenium>=4.0.0
-webdriver-manager>=3.8.0
 requests>=2.31.0
 urllib3>=2.0.0


### PR DESCRIPTION
- Remove selenium>=4.0.0 and webdriver-manager>=3.8.0
- Keep only requests and urllib3 which are actually used
- Requests implementation doesn't need selenium dependencies