### PR TITLE
.gitignoreを追加し認証情報の誤コミットを防止

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# 認証情報・環境変数ファイル
+.env
+
+# デバッグログファイル（JWTトークン等の機密情報を含む可能性あり）
+*.log
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+dist/
+build/
+
+# 仮想環境
+venv/
+.venv/
+env/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# ダウンロードされたデータファイル
+riyourireki_*.csv
+riyourireki_*.pdf


### PR DESCRIPTION
## Summary

- `.gitignore`を新規作成し、機密情報や不要ファイルのGit追跡を防止
- 除外対象: `.env`（認証情報）、`*.log`（デバッグログ）、`__pycache__/`、`venv/`、ダウンロード済みデータファイル等

## 対象Issue

Closes #30

## テスト計画

プログラムコードの変更を伴わないため、単体テストは不要です。以下を手動確認してください：

- [x] `.env`ファイルを作成し、`git status`で追跡対象外になることを確認
- [x] `*.log`ファイルを作成し、`git status`で追跡対象外になることを確認
- [x] `riyourireki_*.csv` / `riyourireki_*.pdf`が追跡対象外になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)