### PR TITLE
デバッグ出力からJWTトークンの平文出力を完全に削除

### DIFF
--- a/fukuoka_water_downloader.py
+++ b/fukuoka_water_downloader.py
@@ -8,7 +8,6 @@ This script automatically downloads billing data from Fukuoka City Water Bureau 
 """
 
 import argparse
-import base64
 import csv
 import getpass
 import json
@@ -194,7 +193,10 @@ class FukuokaWaterDownloader:
         if headers:
             message += "Headers:\n"
             for key, value in headers.items():
-                message += f"  {key}: {value}\n"
+                if key.lower() == 'authorization':
+                    message += f"  {key}: [MASKED]\n"
+                else:
+                    message += f"  {key}: {value}\n"
         
         if data:
             message += "Request Body:\n"
@@ -231,6 +233,8 @@ class FukuokaWaterDownloader:
                 json_data = response.json()
                 masked_data = json_data.copy() if isinstance(json_data, dict) else json_data
                 if isinstance(masked_data, dict):
+                    if 'token' in masked_data:
+                        masked_data['token'] = '[MASKED]'
                     if 'data' in masked_data and isinstance(masked_data['data'], dict):
                         if 'mailAddress' in masked_data['data']:
                             masked_data['data']['mailAddress'] = '[MASKED_EMAIL]'
@@ -436,26 +440,6 @@ class FukuokaWaterDownloader:
                     self.jwt_token = response_data['token']
                     self.print_output("ログインに成功しました")
                     
-                    try:
-                        payload = self.jwt_token.split('.')[1]
-                        payload += '=' * (4 - len(payload) % 4)
-                        decoded = base64.b64decode(payload)
-                        jwt_data = json.loads(decoded)
-                        if self.debug:
-                            masked_jwt_data = jwt_data.copy()
-                            if self.debug_log_file:
-                                logging.debug(f"JWT Payload: {json.dumps(masked_jwt_data, indent=2, ensure_ascii=False)}")
-                            else:
-                                self.print_output(f"JWT Payload: {json.dumps(masked_jwt_data, indent=2, ensure_ascii=False)}")
-                    except Exception as e:
-                        self.print_output(f"JWT解析エラー: {e}", is_error=True)
-                        if self.debug:
-                            error_msg = f"JWT解析詳細エラー: {str(e)}"
-                            if self.debug_log_file:
-                                logging.debug(error_msg)
-                            else:
-                                self.print_output(error_msg)
-                    
                     if not self.get_user_data():
                         self.print_output("ユーザーデータの取得に失敗しました", is_error=True)
                         return False
@@ -533,13 +517,11 @@ class FukuokaWaterDownloader:
             self.print_output("ファイル作成要求中...")
             if self.debug and not self.quiet:
                 self.print_output("=== AUTHENTICATION DEBUG INFO ===")
-                self.print_output(f"JWT Token (first 100 chars): {self.jwt_token[:100]}...")
                 self.print_output(f"User ID (dwKey): {self.user_id}")
                 self.print_output(f"Create URL: {create_url}")
                 self.print_output(f"Request body: {json_body}")
                 self.print_output(f"Request body UTF-8 bytes: {len(json_bytes)}")
                 self.print_output(f"Request body hex: {json_bytes.hex()}")
-                self.print_output(f"Authorization header: {headers.get('Authorization', 'NOT SET')[:100]}...")
                 self.print_output("=" * 40)
             
             self.log_request("POST", create_url, headers, create_data)

--- a/tests/test_debug_token_masking.py
+++ b/tests/test_debug_token_masking.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""デバッグ出力にJWTトークンが含まれないことを検証するテスト"""
+
+import json
+import sys
+import os
+import unittest
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from fukuoka_water_downloader import FukuokaWaterDownloader
+
+
+class TestDebugTokenMasking(unittest.TestCase):
+    """デバッグ出力でJWTトークンがマスクされることを検証"""
+
+    def setUp(self):
+        self.downloader = FukuokaWaterDownloader(debug=True, quiet=False)
+        self.fake_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+
+    def test_log_request_masks_authorization_header(self):
+        """log_requestでAuthorizationヘッダーが[MASKED]になること"""
+        headers = {
+            'Content-Type': 'application/json',
+            'Authorization': self.fake_token,
+        }
+        output = StringIO()
+        with patch('sys.stdout', output):
+            self.downloader.log_request("GET", "https://example.com/api", headers)
+
+        result = output.getvalue()
+        self.assertNotIn(self.fake_token, result)
+        self.assertIn("Authorization: [MASKED]", result)
+        self.assertIn("Content-Type: application/json", result)
+
+    def test_log_request_masks_authorization_case_insensitive(self):
+        """Authorizationヘッダーの大文字小文字を問わずマスクされること"""
+        headers = {
+            'authorization': self.fake_token,
+        }
+        output = StringIO()
+        with patch('sys.stdout', output):
+            self.downloader.log_request("GET", "https://example.com/api", headers)
+
+        result = output.getvalue()
+        self.assertNotIn(self.fake_token, result)
+        self.assertIn("[MASKED]", result)
+
+    def test_log_response_masks_token_in_json_body(self):
+        """log_responseでレスポンスボディ内のtokenフィールドがマスクされること"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.url = "https://example.com/api"
+        mock_response.headers = {
+            'content-type': 'application/json',
+        }
+        mock_response.json.return_value = {
+            'result': '00000',
+            'token': self.fake_token,
+            'data': {'someField': 'value'}
+        }
+
+        output = StringIO()
+        with patch('sys.stdout', output):
+            self.downloader.log_response(mock_response)
+
+        result = output.getvalue()
+        self.assertNotIn(self.fake_token, result)
+        self.assertIn('"token": "[MASKED]"', result)
+        self.assertIn('"result": "00000"', result)
+
+    def test_log_response_masks_email_in_data(self):
+        """log_responseで既存のメールマスクも引き続き動作すること"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.url = "https://example.com/api"
+        mock_response.headers = {
+            'content-type': 'application/json',
+        }
+        mock_response.json.return_value = {
+            'token': self.fake_token,
+            'data': {'mailAddress': 'user@example.com'}
+        }
+
+        output = StringIO()
+        with patch('sys.stdout', output):
+            self.downloader.log_response(mock_response)
+
+        result = output.getvalue()
+        self.assertNotIn(self.fake_token, result)
+        self.assertNotIn('user@example.com', result)
+        self.assertIn('[MASKED_EMAIL]', result)
+
+    def test_authentication_debug_info_no_token(self):
+        """AUTHENTICATION DEBUG INFOにJWTトークンが含まれないこと"""
+        self.downloader.jwt_token = self.fake_token
+        self.downloader.user_id = "test_user_123"
+
+        output = StringIO()
+        with patch('sys.stdout', output):
+            self.downloader.print_output("=== AUTHENTICATION DEBUG INFO ===")
+            self.downloader.print_output(f"User ID (dwKey): {self.downloader.user_id}")
+            self.downloader.print_output("=" * 40)
+
+        result = output.getvalue()
+        self.assertNotIn(self.fake_token, result)
+        self.assertIn("test_user_123", result)
+
+    def test_no_jwt_payload_output(self):
+        """JWTペイロードの出力コードが削除されていること（ソースコード検証）"""
+        import inspect
+        source = inspect.getsource(FukuokaWaterDownloader.login)
+        self.assertNotIn("JWT Payload:", source)
+        self.assertNotIn("base64.b64decode", source)
+        self.assertNotIn("jwt_data", source)
+
+    def test_no_jwt_token_first_100_chars(self):
+        """'JWT Token (first 100 chars)'の出力が削除されていること"""
+        import inspect
+        source = inspect.getsource(FukuokaWaterDownloader.download_billing_data)
+        self.assertNotIn("JWT Token (first 100 chars)", source)
+        self.assertNotIn("Authorization header:", source)
+
+    def test_log_request_without_headers(self):
+        """ヘッダーなしのlog_requestが正常に動作すること"""
+        output = StringIO()
+        with patch('sys.stdout', output):
+            self.downloader.log_request("GET", "https://example.com/api")
+
+        result = output.getvalue()
+        self.assertIn("GET", result)
+        self.assertIn("https://example.com/api", result)
+
+    def test_log_request_masks_password_in_body(self):
+        """リクエストボディ内のパスワードが引き続きマスクされること"""
+        data = {"loginId": "user@example.com", "password": "secret123"}
+        output = StringIO()
+        with patch('sys.stdout', output):
+            self.downloader.log_request("POST", "https://example.com/login", data=data)
+
+        result = output.getvalue()
+        self.assertNotIn("secret123", result)
+        self.assertNotIn("user@example.com", result)
+        self.assertIn("[MASKED_PASSWORD]", result)
+        self.assertIn("[MASKED_EMAIL]", result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- `log_request`: Authorizationヘッダーの値を `[MASKED]` に置換
- `log_response`: レスポンスJSON内の `token` フィールドを `[MASKED]` に置換
- `login`: JWTペイロードのデコード・出力コードを完全削除（`base64` importも削除）
- `download_billing_data`: AUTHENTICATION DEBUG INFO ブロックからJWTトークン行とAuthorizationヘッダー行を削除

## 対象Issue

Closes #32

## Test plan

単体テスト（9件）を `tests/test_debug_token_masking.py` に追加済み：

```bash
source venv/bin/activate && python3 tests/test_debug_token_masking.py -v
```

- [x] `log_request`でAuthorizationヘッダーがマスクされること
- [x] Authorization の大文字小文字を問わずマスクされること
- [x] `log_response`でtokenフィールドがマスクされること
- [x] 既存のメールアドレスマスクが引き続き動作すること
- [x] AUTHENTICATION DEBUG INFOにトークンが含まれないこと
- [x] JWTペイロード出力コードが削除されていること（ソースコード検証）
- [x] `JWT Token (first 100 chars)` 出力が削除されていること
- [x] ヘッダーなしのlog_requestが正常動作すること
- [x] パスワードマスクが引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)