### PR TITLE
APIレスポンスのファイル名にパストラバーサル防止を追加

### DIFF
--- a/fukuoka_water_downloader.py
+++ b/fukuoka_water_downloader.py
@@ -172,6 +172,15 @@ class FukuokaWaterDownloader:
         else:
             logging.basicConfig(level=logging.DEBUG, format='%(message)s')
 
+    @staticmethod
+    def sanitize_filename(filename: str) -> str:
+        """ファイル名をサニタイズしてパストラバーサルを防止"""
+        filename = filename.replace('\\', '/')
+        filename = os.path.basename(filename)
+        if not filename:
+            raise ValueError("ファイル名が空です")
+        return filename
+
     def mask_email(self, email: str) -> str:
         """メールアドレスの一部をマスク"""
         if '@' in email:
@@ -554,7 +563,7 @@ class FukuokaWaterDownloader:
                 return None, None
             
             if 'data' in create_result and 'fileName' in create_result['data']:
-                filename = create_result['data']['fileName']
+                filename = self.sanitize_filename(create_result['data']['fileName'])
             else:
                 import time
                 timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
@@ -646,6 +655,7 @@ class FukuokaWaterDownloader:
     def save_data(self, data: bytes, filename: str, output_format: str):
         """データをファイルに保存"""
         try:
+            filename = self.sanitize_filename(filename)
             if output_format.lower() == 'csv':
                 with open(filename, 'wb') as f:
                     f.write(data)

--- a/tests/test_path_traversal.py
+++ b/tests/test_path_traversal.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""パストラバーサル防止のテスト"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from fukuoka_water_downloader import FukuokaWaterDownloader
+
+
+class TestSanitizeFilename(unittest.TestCase):
+    """sanitize_filenameメソッドのテスト"""
+
+    def test_normal_filename(self):
+        """通常のファイル名はそのまま返される"""
+        self.assertEqual(
+            FukuokaWaterDownloader.sanitize_filename("riyourireki_123.csv"),
+            "riyourireki_123.csv"
+        )
+
+    def test_path_traversal_relative(self):
+        """相対パストラバーサルが除去される"""
+        self.assertEqual(
+            FukuokaWaterDownloader.sanitize_filename("../../etc/passwd"),
+            "passwd"
+        )
+
+    def test_path_traversal_deep(self):
+        """深い相対パストラバーサルが除去される"""
+        self.assertEqual(
+            FukuokaWaterDownloader.sanitize_filename("../../../.ssh/authorized_keys"),
+            "authorized_keys"
+        )
+
+    def test_absolute_path_unix(self):
+        """Unix絶対パスからファイル名のみ抽出される"""
+        self.assertEqual(
+            FukuokaWaterDownloader.sanitize_filename("/etc/cron.d/malicious"),
+            "malicious"
+        )
+
+    def test_path_with_backslash(self):
+        """バックスラッシュを含むパスが処理される"""
+        result = FukuokaWaterDownloader.sanitize_filename("..\\..\\Windows\\System32\\evil.exe")
+        self.assertNotIn("..", result)
+        self.assertNotIn("\\", result)
+
+    def test_empty_filename_raises(self):
+        """空のファイル名でValueErrorが発生する"""
+        with self.assertRaises(ValueError):
+            FukuokaWaterDownloader.sanitize_filename("")
+
+    def test_only_traversal_raises(self):
+        """パス部分のみ（ファイル名なし）でValueErrorが発生する"""
+        with self.assertRaises(ValueError):
+            FukuokaWaterDownloader.sanitize_filename("../../")
+
+    def test_dot_filename(self):
+        """ドットで始まるファイル名は許可される"""
+        self.assertEqual(
+            FukuokaWaterDownloader.sanitize_filename(".bashrc"),
+            ".bashrc"
+        )
+
+    def test_filename_with_spaces(self):
+        """スペースを含むファイル名はそのまま返される"""
+        self.assertEqual(
+            FukuokaWaterDownloader.sanitize_filename("my file.csv"),
+            "my file.csv"
+        )
+
+    def test_subdirectory_stripped(self):
+        """サブディレクトリが除去されファイル名のみ返される"""
+        self.assertEqual(
+            FukuokaWaterDownloader.sanitize_filename("subdir/file.csv"),
+            "file.csv"
+        )
+
+
+class TestSaveDataPathTraversal(unittest.TestCase):
+    """save_dataメソッドがパストラバーサルを防止することのテスト"""
+
+    def setUp(self):
+        self.downloader = FukuokaWaterDownloader(debug=False, quiet=True)
+        self.test_data = b"test,data\n1,2\n"
+
+    def test_save_data_strips_path(self):
+        """save_dataがパストラバーサルを含むファイル名をサニタイズして保存する"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                self.downloader.save_data(self.test_data, "../../evil.csv", "csv")
+                # カレントディレクトリに"evil.csv"として保存されること
+                self.assertTrue(os.path.exists(os.path.join(tmpdir, "evil.csv")))
+                # 親ディレクトリには書き込まれていないこと
+                self.assertFalse(os.path.exists(os.path.join(tmpdir, "..", "evil.csv")))
+            finally:
+                os.chdir(original_cwd)
+
+    def test_save_data_normal_filename(self):
+        """save_dataが通常のファイル名で正常に保存する"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                self.downloader.save_data(self.test_data, "riyourireki_123.csv", "csv")
+                saved_path = os.path.join(tmpdir, "riyourireki_123.csv")
+                self.assertTrue(os.path.exists(saved_path))
+                with open(saved_path, 'rb') as f:
+                    self.assertEqual(f.read(), self.test_data)
+            finally:
+                os.chdir(original_cwd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- `sanitize_filename`静的メソッドを追加し、`os.path.basename()`でファイル名のみを抽出
- バックスラッシュ(`\`)をスラッシュに正規化してからbasenameを適用（Linux環境でのWindows形式パス対策）
- APIレスポンスの`fileName`取得箇所（`download_billing_data`）でサニタイズを適用
- `save_data`メソッドでも防御的にサニタイズを適用

## 対象Issue

Closes #33

## Test plan

単体テスト（12件）を `tests/test_path_traversal.py` に追加済み：

```bash
source venv/bin/activate && python3 tests/test_path_traversal.py -v
```

- [x] 通常のファイル名がそのまま返される
- [x] `../../etc/passwd` → `passwd` に変換される
- [x] 深い相対パストラバーサルが除去される
- [x] Unix絶対パスからファイル名のみ抽出される
- [x] バックスラッシュを含むパスが処理される
- [x] 空のファイル名でValueErrorが発生する
- [x] パス部分のみ（ファイル名なし）でValueErrorが発生する
- [x] ドットで始まるファイル名は許可される
- [x] スペースを含むファイル名はそのまま返される
- [x] サブディレクトリが除去される
- [x] `save_data`がパストラバーサルを防止して保存する
- [x] `save_data`が通常のファイル名で正常に保存する

🤖 Generated with [Claude Code](https://claude.com/claude-code)