### PR TITLE
TLS証明書検証を明示的に有効化

### DIFF
--- a/fukuoka_water_downloader.py
+++ b/fukuoka_water_downloader.py
@@ -53,6 +53,8 @@ class FukuokaWaterDownloader:
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
         
+        self.session.verify = True
+
         self.session.headers.update({
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0'
         })

--- a/tests/test_tls_verify.py
+++ b/tests/test_tls_verify.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""TLS証明書検証が明示的に有効化されていることを検証するテスト"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from fukuoka_water_downloader import FukuokaWaterDownloader
+
+
+class TestTLSVerify(unittest.TestCase):
+    """セッションのTLS証明書検証設定のテスト"""
+
+    def test_session_verify_is_true(self):
+        """セッションのverify属性がTrueに設定されていること"""
+        downloader = FukuokaWaterDownloader(debug=False, quiet=True)
+        self.assertTrue(downloader.session.verify)
+
+    def test_session_verify_is_explicitly_true(self):
+        """verify属性がbool型のTrueであること（文字列やパス指定ではない）"""
+        downloader = FukuokaWaterDownloader(debug=False, quiet=True)
+        self.assertIs(downloader.session.verify, True)
+
+    def test_source_contains_explicit_verify(self):
+        """ソースコードにverify = Trueが明示的に記述されていること"""
+        import inspect
+        source = inspect.getsource(FukuokaWaterDownloader.setup_session)
+        self.assertIn("verify = True", source)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- `setup_session`メソッドで `self.session.verify = True` を明示的に設定
- requestsライブラリのデフォルト動作に依存せず、セキュリティ意図をコードで明文化

## 対象Issue

Closes #34

## Test plan

単体テスト（3��）を `tests/test_tls_verify.py` に追加済み：

```bash
source venv/bin/activate && python3 tests/test_tls_verify.py -v
```

- [x] セッションのverify属性がTrueに設定されていること
- [x] verify属性がbool型のTrueであること
- [x] ソースコードに`verify = True`が明示的に記述されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)