### PR TITLE
デバッグログファイルのパーミッションを0o600に制限

### DIFF
--- a/fukuoka_water_downloader.py
+++ b/fukuoka_water_downloader.py
@@ -171,6 +171,10 @@ class FukuokaWaterDownloader:
                     logging.StreamHandler()
                 ]
             )
+            try:
+                os.chmod(self.debug_log_file, 0o600)
+            except OSError:
+                pass
         else:
             logging.basicConfig(level=logging.DEBUG, format='%(message)s')
 

--- a/tests/test_log_file_permissions.py
+++ b/tests/test_log_file_permissions.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""デバッグログファイルのパーミッションが制限されることを検証するテスト"""
+
+import os
+import stat
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from fukuoka_water_downloader import FukuokaWaterDownloader
+
+
+class TestLogFilePermissions(unittest.TestCase):
+    """デバッグログファイルのパーミッションテスト"""
+
+    def test_log_file_permission_is_600(self):
+        """デバッグログファイルが0o600（所有者のみ読み書き可能）で作成されること"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "test_debug.log")
+            FukuokaWaterDownloader(
+                debug=True, debug_log_file=log_path, quiet=False
+            )
+            self.assertTrue(os.path.exists(log_path))
+            mode = stat.S_IMODE(os.stat(log_path).st_mode)
+            self.assertEqual(mode, 0o600,
+                             f"期待: 0o600, 実際: {oct(mode)}")
+
+    def test_log_file_not_group_readable(self):
+        """デバッグログファイルがグループから読み取り不可であること"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "test_debug.log")
+            FukuokaWaterDownloader(
+                debug=True, debug_log_file=log_path, quiet=False
+            )
+            mode = stat.S_IMODE(os.stat(log_path).st_mode)
+            self.assertFalse(mode & stat.S_IRGRP,
+                             "グループ読み取り権限が付与されています")
+
+    def test_log_file_not_other_readable(self):
+        """デバッグログファイルが他ユーザーから読み取り不可であること"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "test_debug.log")
+            FukuokaWaterDownloader(
+                debug=True, debug_log_file=log_path, quiet=False
+            )
+            mode = stat.S_IMODE(os.stat(log_path).st_mode)
+            self.assertFalse(mode & stat.S_IROTH,
+                             "他ユーザー読み取り権限が付与されています")
+
+    def test_no_log_file_without_debug_log_option(self):
+        """debug_log_file未指定時にログファイルが作成されないこと"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "should_not_exist.log")
+            FukuokaWaterDownloader(
+                debug=True, debug_log_file=None, quiet=False
+            )
+            self.assertFalse(os.path.exists(log_path))
+
+    def test_source_contains_chmod(self):
+        """ソースコードにos.chmod呼び出しが含まれること"""
+        import inspect
+        source = inspect.getsource(FukuokaWaterDownloader.setup_debug_logging)
+        self.assertIn("os.chmod", source)
+        self.assertIn("0o600", source)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- `setup_debug_logging`でログファイル作成後に `os.chmod(path, 0o600)` を適用
- 所有者のみ読み書き可能に制限し、共有サーバー等での情報漏洩を防止
- `OSError`発生時（Windows等パーミッション非対応環境）は警告なしでスキップ

## 対象Issue

Closes #35

## Test plan

単体テスト（5件）を `tests/test_log_file_permissions.py` に追加済み：

```bash
source venv/bin/activate && python3 tests/test_log_file_permissions.py -v
```

- [x] ログファイルが0o600で作成されること
- [x] グループ読み取り権限が付与されていないこと
- [x] 他ユーザー読み取り権限が付与されていないこと
- [x] debug_log_file未指定時にログファイルが作成されないこと
- [x] ソースコードにos.chmod呼び出しが含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)