### PR TITLE
run()終了時にJWTトークンとユーザーIDを明示的にクリア

### DIFF
--- a/fukuoka_water_downloader.py
+++ b/fukuoka_water_downloader.py
@@ -717,6 +717,9 @@ class FukuokaWaterDownloader:
         except Exception as e:
             self.print_output(f"処理中にエラーが発生しました: {e}", is_error=True)
             return False
+        finally:
+            self.jwt_token = None
+            self.user_id = None
 
 
 def main():

--- a/tests/test_credential_cleanup.py
+++ b/tests/test_credential_cleanup.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""処理完了後にJWTトークンとユーザーIDがクリアされることを検証するテスト"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from fukuoka_water_downloader import FukuokaWaterDownloader
+
+
+class TestCredentialCleanup(unittest.TestCase):
+    """run()メソッド完了後の認証情報クリアテスト"""
+
+    def setUp(self):
+        self.downloader = FukuokaWaterDownloader(debug=False, quiet=True)
+
+    @patch.object(FukuokaWaterDownloader, 'get_credentials', return_value=('test@example.com', 'password'))
+    @patch.object(FukuokaWaterDownloader, 'login', return_value=True)
+    @patch.object(FukuokaWaterDownloader, 'download_billing_data', return_value=(b'data', 'test.csv'))
+    @patch.object(FukuokaWaterDownloader, 'save_data')
+    def test_tokens_cleared_after_success(self, mock_save, mock_download, mock_login, mock_creds):
+        """正常終了後にjwt_tokenとuser_idがNoneになること"""
+        self.downloader.jwt_token = "fake_token"
+        self.downloader.user_id = "fake_user"
+
+        self.downloader.run()
+
+        self.assertIsNone(self.downloader.jwt_token)
+        self.assertIsNone(self.downloader.user_id)
+
+    @patch.object(FukuokaWaterDownloader, 'get_credentials', return_value=('test@example.com', 'password'))
+    @patch.object(FukuokaWaterDownloader, 'login', return_value=False)
+    def test_tokens_cleared_after_login_failure(self, mock_login, mock_creds):
+        """ログイン失敗後にjwt_tokenとuser_idがNoneになること"""
+        self.downloader.jwt_token = "fake_token"
+        self.downloader.user_id = "fake_user"
+
+        self.downloader.run()
+
+        self.assertIsNone(self.downloader.jwt_token)
+        self.assertIsNone(self.downloader.user_id)
+
+    @patch.object(FukuokaWaterDownloader, 'get_credentials', return_value=('test@example.com', 'password'))
+    @patch.object(FukuokaWaterDownloader, 'login', return_value=True)
+    @patch.object(FukuokaWaterDownloader, 'download_billing_data', return_value=(None, None))
+    def test_tokens_cleared_after_download_failure(self, mock_download, mock_login, mock_creds):
+        """ダウンロード失敗後にjwt_tokenとuser_idがNoneになること"""
+        self.downloader.jwt_token = "fake_token"
+        self.downloader.user_id = "fake_user"
+
+        self.downloader.run()
+
+        self.assertIsNone(self.downloader.jwt_token)
+        self.assertIsNone(self.downloader.user_id)
+
+    @patch.object(FukuokaWaterDownloader, 'get_credentials', side_effect=Exception("unexpected error"))
+    def test_tokens_cleared_after_exception(self, mock_creds):
+        """例外発生後にjwt_tokenとuser_idがNoneになること"""
+        self.downloader.jwt_token = "fake_token"
+        self.downloader.user_id = "fake_user"
+
+        self.downloader.run()
+
+        self.assertIsNone(self.downloader.jwt_token)
+        self.assertIsNone(self.downloader.user_id)
+
+    def test_source_contains_finally_block(self):
+        """runメソッドにfinallyブロックが含まれること"""
+        import inspect
+        source = inspect.getsource(FukuokaWaterDownloader.run)
+        self.assertIn("finally:", source)
+        self.assertIn("self.jwt_token = None", source)
+        self.assertIn("self.user_id = None", source)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- `run()`メソッドに`finally`ブロックを追加
- 正常終了・異常終了を問わず `self.jwt_token` と `self.user_id` を `None` に設定
- メモリダンプやcore dumpからの認証情報抽出リスクを軽減

## 対象Issue

Closes #36

## Test plan

単体テスト（5件）を `tests/test_credential_cleanup.py` に追加済み：

```bash
source venv/bin/activate && python3 tests/test_credential_cleanup.py -v
```

- [x] 正常終了後にjwt_tokenとuser_idがNoneになること
- [x] ログイン失敗後にクリアされること
- [x] ダウンロード失敗後にクリアされること
- [x] 例外発生後にクリアされること
- [x] ソースコードにfinallyブロックが含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)