### PR TITLE
User-Agent文字列をクラス定数として一元管理

### DIFF
--- a/fukuoka_water_downloader.py
+++ b/fukuoka_water_downloader.py
@@ -26,8 +26,10 @@ from dotenv import load_dotenv
 
 class FukuokaWaterDownloader:
     """福岡市水道局アプリからデータをダウンロードするクラス"""
-    
-    def __init__(self, debug: bool = False, debug_log_file: str = None, 
+
+    DEFAULT_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0'
+
+    def __init__(self, debug: bool = False, debug_log_file: str = None,
                  quiet: bool = False, filename_only: bool = False):
         self.session = requests.Session()
         self.base_url = "https://www.suido-madoguchi-fukuoka.jp"
@@ -56,7 +58,7 @@ class FukuokaWaterDownloader:
         self.session.verify = True
 
         self.session.headers.update({
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0'
+            'User-Agent': self.DEFAULT_USER_AGENT
         })
 
     def convert_date_to_kenyin_format(self, date_str: str) -> str:
@@ -276,7 +278,7 @@ class FukuokaWaterDownloader:
                 'Access-Control-Request-Headers': ','.join(request_headers),
                 'Origin': 'https://www.suido-madoguchi-fukuoka.jp',
                 'Referer': 'https://www.suido-madoguchi-fukuoka.jp/',
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0',
+                'User-Agent': self.DEFAULT_USER_AGENT,
                 'accept': '*/*',
                 'accept-language': 'ja,en-US;q=0.7,en;q=0.3',
                 'accept-encoding': 'gzip, deflate, br, zstd',
@@ -340,7 +342,7 @@ class FukuokaWaterDownloader:
                 'te': 'trailers',
                 'Origin': 'https://www.suido-madoguchi-fukuoka.jp',
                 'Referer': 'https://www.suido-madoguchi-fukuoka.jp/',
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0',
+                'User-Agent': self.DEFAULT_USER_AGENT,
                 'Sec-Fetch-Dest': 'empty',
                 'Sec-Fetch-Mode': 'cors',
                 'Sec-Fetch-Site': 'same-site'
@@ -523,7 +525,7 @@ class FukuokaWaterDownloader:
                 'te': 'trailers',
                 'Origin': 'https://www.suido-madoguchi-fukuoka.jp',
                 'Referer': 'https://www.suido-madoguchi-fukuoka.jp/',
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0',
+                'User-Agent': self.DEFAULT_USER_AGENT,
                 'Sec-Fetch-Dest': 'empty',
                 'Sec-Fetch-Mode': 'cors',
                 'Sec-Fetch-Site': 'same-site'
@@ -590,7 +592,7 @@ class FukuokaWaterDownloader:
                 'te': 'trailers',
                 'Origin': 'https://www.suido-madoguchi-fukuoka.jp',
                 'Referer': 'https://www.suido-madoguchi-fukuoka.jp/',
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0',
+                'User-Agent': self.DEFAULT_USER_AGENT,
                 'Sec-Fetch-Dest': 'empty',
                 'Sec-Fetch-Mode': 'cors',
                 'Sec-Fetch-Site': 'same-site'

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""User-Agentが定数として一元管理されていることを検証するテスト"""
+
+import inspect
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from fukuoka_water_downloader import FukuokaWaterDownloader
+
+
+class TestUserAgent(unittest.TestCase):
+    """User-Agent定数管理のテスト"""
+
+    def test_default_user_agent_defined(self):
+        """DEFAULT_USER_AGENTクラス定数が定義されていること"""
+        self.assertTrue(hasattr(FukuokaWaterDownloader, 'DEFAULT_USER_AGENT'))
+        self.assertIsInstance(FukuokaWaterDownloader.DEFAULT_USER_AGENT, str)
+        self.assertIn('Mozilla', FukuokaWaterDownloader.DEFAULT_USER_AGENT)
+
+    def test_session_uses_default_user_agent(self):
+        """セッションのUser-AgentがDEFAULT_USER_AGENTと一致すること"""
+        downloader = FukuokaWaterDownloader(debug=False, quiet=True)
+        self.assertEqual(
+            downloader.session.headers.get('User-Agent'),
+            FukuokaWaterDownloader.DEFAULT_USER_AGENT
+        )
+
+    def test_no_hardcoded_user_agent_in_methods(self):
+        """メソッド内にUser-Agent文字列がハードコードされていないこと"""
+        hardcoded_pattern = re.compile(r"Mozilla/5\.0.*Firefox")
+        methods = [
+            FukuokaWaterDownloader.setup_session,
+            FukuokaWaterDownloader.send_cors_preflight,
+            FukuokaWaterDownloader.get_user_data,
+            FukuokaWaterDownloader.login,
+            FukuokaWaterDownloader.download_billing_data,
+        ]
+        for method in methods:
+            source = inspect.getsource(method)
+            matches = hardcoded_pattern.findall(source)
+            self.assertEqual(
+                len(matches), 0,
+                f"{method.__name__}にUser-Agentがハードコードされています: {matches}"
+            )
+
+    def test_all_methods_reference_constant(self):
+        """User-Agentを使用するメソッドがDEFAULT_USER_AGENTを参照していること"""
+        methods_with_ua = [
+            FukuokaWaterDownloader.setup_session,
+            FukuokaWaterDownloader.send_cors_preflight,
+            FukuokaWaterDownloader.get_user_data,
+            FukuokaWaterDownloader.download_billing_data,
+        ]
+        for method in methods_with_ua:
+            source = inspect.getsource(method)
+            self.assertIn(
+                'DEFAULT_USER_AGENT', source,
+                f"{method.__name__}がDEFAULT_USER_AGENTを参照していません"
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- `DEFAULT_USER_AGENT`クラス定数を追加し、5箇所のハードコードされたUser-Agent文字列を集約
- 将来のUser-Agent更新時に1箇所の変更で済むように改善

## 対象Issue

Closes #37

## Test plan

単体テスト（4件）を `tests/test_user_agent.py` に追加済み：

```bash
source venv/bin/activate && python3 tests/test_user_agent.py -v
```

- [x] DEFAULT_USER_AGENTクラス定数が定義されていること
- [x] セッションのUser-AgentがDEFAULT_USER_AGENTと一致すること
- [x] メソッド内にUser-Agent文字列がハードコードされていないこと
- [x] User-Agentを使用するメソッドがDEFAULT_USER_AGENTを参照していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)