### PR TITLE
--password引数使用時にセキュリティ警告を表示

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,24 +140,9 @@ python3 fukuoka_water_downloader.py --date-from "R6.1" --date-to "2024年12月"
 
 ### 認証情報の設定
 
-認証情報は以下の方法で設定できます（優先順位順）：
+認証情報は以下の方法で設定できます（セキュリティの観点から推奨順に記載）：
 
-#### 1. コマンドライン引数（最優先）
-```bash
-python3 fukuoka_water_downloader.py --email your_email@example.com --password your_password
-```
-
-#### 2. 環境変数
-```bash
-# 認証情報を環境変数に設定
-export FUKUOKA_WATER_EMAIL="your_email@example.com"
-export FUKUOKA_WATER_PASSWORD="your_password"
-
-# 設定後はメールアドレスとパスワードの指定不要
-python3 fukuoka_water_downloader.py --format pdf
-```
-
-#### 3. .envファイル（最低優先度）
+#### 1. .envファイル（推奨 - 自動化にも対応）
 ```bash
 # .envファイルを作成
 cp .env.example .env
@@ -170,10 +155,28 @@ echo "FUKUOKA_WATER_PASSWORD=your_password" >> .env
 python3 fukuoka_water_downloader.py --format pdf
 ```
 
-#### 4. 対話的入力
-上記のいずれも設定されていない場合、実行時に入力を求められます。
+#### 2. 環境変数
+```bash
+# 認証情報を環境変数に設定
+export FUKUOKA_WATER_EMAIL="your_email@example.com"
+export FUKUOKA_WATER_PASSWORD="your_password"
 
-**注意**: より高い優先順位の設定が存在する場合、低い優先順位の設定は無視されます。
+# 設定後はメールアドレスとパスワードの指定不要
+python3 fukuoka_water_downloader.py --format pdf
+```
+
+#### 3. 対話的入力（最も安全）
+上記のいずれも設定されていない場合、実行時に入力を求められます。パスワードは画面に表示されません。
+
+#### 4. コマンドライン引数
+
+> **セキュリティ警告**: `--password`引数で指定したパスワードはシェル履歴（`~/.bash_history`等）や`ps`コマンドの出力に残ります。上記1〜3の方法を推奨します。
+
+```bash
+python3 fukuoka_water_downloader.py --email your_email@example.com --password your_password
+```
+
+**注意**: 複数の方法で設定されている場合、コマンドライン引数 > 環境変数/.envファイル > 対話入力の優先順位で適用されます。
 
 ### Pythonスクリプトとしての使用
 

--- a/fukuoka_water_downloader.py
+++ b/fukuoka_water_downloader.py
@@ -731,35 +731,43 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 使用例:
+  # 対話入力（最も安全 - パスワードは画面に表示されません）
   python fukuoka_water_downloader.py
 
-  python fukuoka_water_downloader.py --email user@example.com --password mypassword
+  # .envファイル（推奨 - 自動化にも対応）
+  cp .env.example .env  # .envを編集して認証情報を設定
+  python fukuoka_water_downloader.py
 
+  # 環境変数
   export FUKUOKA_WATER_EMAIL=user@example.com
   export FUKUOKA_WATER_PASSWORD=mypassword
   python fukuoka_water_downloader.py
 
+  # 期間指定
   python fukuoka_water_downloader.py --date-from "令和5年1月" --date-to "令和5年12月"
-
   python fukuoka_water_downloader.py --date-from "2023-01" --date-to "2023-12"
-  python fukuoka_water_downloader.py --date-from "2023年1月" --date-to "2023年12月"
 
+  # 出力形式指定
   python fukuoka_water_downloader.py --format csv --output billing_data.csv
 
-  python fukuoka_water_downloader.py --debug --email user@example.com --password mypassword
-  python fukuoka_water_downloader.py -d -e user@example.com -p mypassword
+  # デバッグモード
+  python fukuoka_water_downloader.py --debug
+  python fukuoka_water_downloader.py --debug-log debug.log
 
-  python fukuoka_water_downloader.py --debug-log debug.log --email user@example.com --password mypassword
-  
-  python fukuoka_water_downloader.py --quiet --email user@example.com --password mypassword
+  # 静寂モード
+  python fukuoka_water_downloader.py --quiet
   python fukuoka_water_downloader.py --filename-only --format csv
+
+セキュリティに関する注意:
+  --password引数はシェル履歴やpsコマンドの出力に残るため、
+  .envファイル、環境変数、または対話入力の使用を推奨します。
         """
     )
     
     parser.add_argument('--email', '-e',
                         help='ログイン用メールアドレス（環境変数 FUKUOKA_WATER_EMAIL でも指定可能）')
     parser.add_argument('--password', '-p',
-                        help='ログイン用パスワード（環境変数 FUKUOKA_WATER_PASSWORD でも指定可能）')
+                        help='ログイン用パスワード（非推奨: シェル履歴に残ります。環境変数 FUKUOKA_WATER_PASSWORD または .envファイルを推奨）')
     parser.add_argument('--date-from', '--from',
                         help='開始期間（例: "令和5年1月", "2023-01", "2023年1月"）')
     parser.add_argument('--date-to', '--to',
@@ -782,6 +790,11 @@ def main():
     
     args = parser.parse_args()
     
+    if args.password:
+        print("警告: --password引数はシェル履歴やpsコマンドの出力に残る可能性があります。"
+              "環境変数、.envファイル、または対話入力の使用を推奨します。",
+              file=sys.stderr)
+
     if args.quiet and args.filename_only:
         print("エラー: --quiet と --filename-only は同時に指定できません", file=sys.stderr)
         sys.exit(1)

--- a/tests/test_password_warning.py
+++ b/tests/test_password_warning.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""--password引数使用時の警告メッセージを検証するテスト"""
+
+import os
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestPasswordWarning(unittest.TestCase):
+    """--password引数使用時のセキュリティ警告テスト"""
+
+    def _run_main_with_args(self, args):
+        """main()を指定引数で実行し、stderrの出力を返す"""
+        from fukuoka_water_downloader import main
+        stderr_capture = StringIO()
+        with patch('sys.argv', ['fukuoka_water_downloader.py'] + args), \
+             patch('sys.stderr', stderr_capture), \
+             patch('fukuoka_water_downloader.FukuokaWaterDownloader.run', return_value=True), \
+             patch('sys.exit'):
+            main()
+        return stderr_capture.getvalue()
+
+    def test_warning_shown_when_password_argument_used(self):
+        """--password引数使用時に警告がstderrに出力されること"""
+        stderr_output = self._run_main_with_args(
+            ['--email', 'test@example.com', '--password', 'secret123']
+        )
+        self.assertIn("警告", stderr_output)
+        self.assertIn("シェル履歴", stderr_output)
+
+    def test_warning_shown_with_short_flag(self):
+        """-p短縮フラグ使用時にも警告が出力されること"""
+        stderr_output = self._run_main_with_args(
+            ['-e', 'test@example.com', '-p', 'secret123']
+        )
+        self.assertIn("警告", stderr_output)
+
+    def test_no_warning_without_password_argument(self):
+        """--password引数未使用時に警告が出力されないこと"""
+        stderr_output = self._run_main_with_args(
+            ['--email', 'test@example.com']
+        )
+        self.assertNotIn("警告", stderr_output)
+
+    def test_no_warning_with_no_arguments(self):
+        """引数なし実行時に警告が出力されないこと"""
+        stderr_output = self._run_main_with_args([])
+        self.assertNotIn("警告", stderr_output)
+
+    def test_warning_recommends_alternatives(self):
+        """警告メッセージが代替手段を案内すること"""
+        stderr_output = self._run_main_with_args(
+            ['--password', 'secret123', '--email', 'test@example.com']
+        )
+        self.assertIn(".env", stderr_output)
+        self.assertIn("環境変数", stderr_output)
+
+    def test_help_text_contains_security_note(self):
+        """--passwordのヘルプテキストに非推奨である旨が記載されていること"""
+        import argparse
+        from fukuoka_water_downloader import main
+        help_output = StringIO()
+        with patch('sys.argv', ['fukuoka_water_downloader.py', '--help']), \
+             patch('sys.stdout', help_output), \
+             self.assertRaises(SystemExit):
+            main()
+        help_text = help_output.getvalue()
+        self.assertIn("非推奨", help_text)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- `--password`引数使用時にstderrへセキュリティ警告を出力
- `--password`のヘルプテキストに「非推奨」と代替手段を明記
- `--help`の使用例からパスワード直接指定を削除し、安全な方法（`.env`/環境変数/対話入力）を案内
- README.mdの認証情報セクションをセキュリティ推奨順（`.env` > 環境変数 > 対話入力 > CLI引数）に再構成
- CLI引数による指定にセキュリティ警告を追記

## 対象Issue

Closes #31

## Test plan

単体テスト（6件）を `tests/test_password_warning.py` に追加済み：

```bash
source venv/bin/activate && python3 tests/test_password_warning.py -v
```

- [x] `--password`引数使用時に警告がstderrに出力されること
- [x] `-p`短縮フラグ使用時にも警告が出力されること
- [x] `--password`引数未使用時に警告が出力されないこと
- [x] 引数なし実行時に警告が出力されないこと
- [x] 警告メッセージが代替手段（`.env`、環境変数）を案内すること
- [x] `--help`テキストに「非推奨」が記載されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)