### PR TITLE
READMEの基本的な使用方法を.envファイル方式に統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,12 @@ pip install -r requirements.txt
 
 #### 基本的な使用方法
 ```bash
-# 環境変数で認証情報を設定
-export FUKUOKA_WATER_EMAIL="your_email@example.com"
-export FUKUOKA_WATER_PASSWORD="your_password"
+# .envファイルに認証情報を設定（初回のみ）
+cp .env.example .env
+# .envを編集してメールアドレスとパスワードを設定
 
 # デフォルト設定で実行（CSV形式、現在の月）
 python3 fukuoka_water_downloader.py
-
-# または直接認証情報を指定
-python3 fukuoka_water_downloader.py --email your_email@example.com --password your_password
 ```
 
 #### 詳細オプション


### PR DESCRIPTION
## Summary

- 「基本的な使用方法」セクションから`export`によるパスワード設定と`--password`引数の例を削除
- `.env`ファイルを使う方法に統一し、認証情報セクションとの一貫性を確保

#31 の追加対応（PR #46 マージ後の修正漏れ）

## Test plan

ドキュメントのみの変更のため、テストは不要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)